### PR TITLE
Force copy steering file to avoid error

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -108,7 +108,7 @@ mkdir -p ${INPUT_DIR} ${INPUT_TEMP}
 TAG=${DETECTOR_VERSION}/${DETECTOR_CONFIG}/${TAG}
 
 # Copy input file from xrootd
-if ! [ -f ${INPUT_DIR}/${INPUT_FILE}]; then
+if ! [ -f ${INPUT_DIR}/${INPUT_FILE} ]; then
   xrdcp ${XRDURL}/${INPUT_FILE} ${INPUT_DIR}
 fi
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -108,7 +108,9 @@ mkdir -p ${INPUT_DIR} ${INPUT_TEMP}
 TAG=${DETECTOR_VERSION}/${DETECTOR_CONFIG}/${TAG}
 
 # Copy input file from xrootd
-xrdcp ${XRDURL}/${INPUT_FILE} ${INPUT_DIR}
+if ! [ -f ${INPUT_DIR}/${INPUT_FILE}]; then
+  xrdcp ${XRDURL}/${INPUT_FILE} ${INPUT_DIR}
+fi
 
 # Output file names
 LOG_DIR=${BASEDIR}/LOG/${TAG}

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -108,7 +108,7 @@ mkdir -p ${INPUT_DIR} ${INPUT_TEMP}
 TAG=${DETECTOR_VERSION}/${DETECTOR_CONFIG}/${TAG}
 
 # Copy input file from xrootd
-if ! [ -f ${INPUT_DIR}/${INPUT_FILE} ]; then
+if ! [ -f ${INPUT_DIR}/${INPUT_FILE} ] ; then
   xrdcp ${XRDURL}/${INPUT_FILE} ${INPUT_DIR}
 fi
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -108,9 +108,7 @@ mkdir -p ${INPUT_DIR} ${INPUT_TEMP}
 TAG=${DETECTOR_VERSION}/${DETECTOR_CONFIG}/${TAG}
 
 # Copy input file from xrootd
-if ! [ -f ${INPUT_DIR}/${INPUT_FILE} ] ; then
-  xrdcp ${XRDURL}/${INPUT_FILE} ${INPUT_DIR}
-fi
+xrdcp -f ${XRDURL}/${INPUT_FILE} ${INPUT_DIR}
 
 # Output file names
 LOG_DIR=${BASEDIR}/LOG/${TAG}


### PR DESCRIPTION
Right now it tries to copy even if the input steering file already exists locally. This is throwing errors in CI during timing calculations.
```
drwxr-xr-x 2 root root 4096 Oct 30 01:36 .
drwxrwxrwt 1 root root 4096 Oct 30 01:36 ..
Run: [ERROR] Local error: file exists:  (destination)
/opt/campaigns/single/scripts/run.sh: Error on line 111: xrdcp ${XRDURL}/${INPUT_FILE} ${INPUT_DIR}
SINGLE/mu-/10GeV/etaScan/mu-_10GeV_eta-1.7,steer,1000000,113.731454676,.11384
$ sort -o results/datasets/timings/$DATA results/datasets/timings/$DATA
```

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
