### PR TITLE
Create the directory structure on xrootd before transferring files 

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -63,7 +63,7 @@ BASEDIR=${DATADIR:-${PWD}}
 
 # XRD Read and Write locations
 XRDURL="root://dtn-eic.jlab.org//work/eic2/EPIC"
-XRDWURL="xroots://dtn2201.jlab.org//eic/eic2/EPIC"
+XRDWURL="xroots://dtn2201.jlab.org//eic/eic2/EPIC/xrdtest"
 
 # Local temp dir
 echo "SLURM_TMPDIR=${SLURM_TMPDIR:-}"
@@ -113,14 +113,23 @@ xrdcp -f ${XRDURL}/${INPUT_FILE} ${INPUT_DIR}
 LOG_DIR=${XRDWURL}/LOG/${TAG}
 LOG_TEMP=${TMPDIR}/LOG/${TAG}
 mkdir -p ${LOG_TEMP}
+if [ "${COPYLOG:-false}" == "true" ] ; then
+  xrdcp --force --recursive ${TMPDIR}/LOG ${XRDWURL}
+fi
 #
 FULL_DIR=${XRDWURL}/FULL/${TAG}
 FULL_TEMP=${TMPDIR}/FULL/${TAG}
 mkdir -p ${FULL_TEMP}
+if [ "${COPYFULL:-false}" == "true" ] ; then 
+  xrdcp --force --recursive ${TMPDIR}/FULL ${XRDWURL}
+fi
 #
 RECO_DIR=${XRDWURL}/RECO/${TAG}
 RECO_TEMP=${TMPDIR}/RECO/${TAG}
 mkdir -p ${RECO_TEMP}
+if [ "${COPYRECO:-false}" == "true" ] ; then
+  xrdcp --force --recursive ${TMPDIR}/RECO ${XRDWURL}
+fi
 
 # Run simulation
 {

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -67,7 +67,7 @@ XRDBASE="/eic/eic2/EPIC/xrdtest"
 
 # XRD Read locations
 XRDRURL="root://dtn-eic.jlab.org/"
-XRDRBASE="/work/eic2/EPIC"  
+XRDRBASE="/work/eic2/EPIC"
 
 # Local temp dir
 echo "SLURM_TMPDIR=${SLURM_TMPDIR:-}"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -61,10 +61,13 @@ fi
 # Output location
 BASEDIR=${DATADIR:-${PWD}}
 
-# XRD Read and Write locations
+# XRD Write locations
 XRDURL="xroots://dtn2201.jlab.org/"
 XRDBASE="/eic/eic2/EPIC/xrdtest"
-XRDRBASE="/eic/eic2/EPIC"  # Separate variable for read base directory for now.
+
+# XRD Read locations
+XRDRURL="root://dtn-eic.jlab.org/"
+XRDRBASE="/work/eic2/EPIC"  
 
 # Local temp dir
 echo "SLURM_TMPDIR=${SLURM_TMPDIR:-}"
@@ -108,7 +111,7 @@ mkdir -p ${INPUT_DIR}
 TAG=${DETECTOR_VERSION}/${DETECTOR_CONFIG}/${TAG}
 
 # Copy input file from xrootd
-xrdcp -f ${XRDURL}/${XRDRBASE}/${INPUT_FILE} ${INPUT_DIR}
+xrdcp -f ${XRDRURL}/${XRDRBASE}/${INPUT_FILE} ${INPUT_DIR}
 
 # Output file names
 LOG_DIR=LOG/${TAG}

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -120,7 +120,7 @@ fi
 FULL_DIR=${XRDWURL}/FULL/${TAG}
 FULL_TEMP=${TMPDIR}/FULL/${TAG}
 mkdir -p ${FULL_TEMP}
-if [ "${COPYFULL:-false}" == "true" ] ; then 
+if [ "${COPYFULL:-false}" == "true" ] ; then
   xrdcp --force --recursive ${TMPDIR}/FULL ${XRDWURL}
 fi
 #

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -64,6 +64,7 @@ BASEDIR=${DATADIR:-${PWD}}
 # XRD Read and Write locations
 XRDURL="xroots://dtn2201.jlab.org/"
 XRDBASE="/eic/eic2/EPIC/xrdtest"
+XRDRBASE="/eic/eic2/EPIC"  # Separate variable for read base directory for now. 
 
 # Local temp dir
 echo "SLURM_TMPDIR=${SLURM_TMPDIR:-}"
@@ -107,7 +108,7 @@ mkdir -p ${INPUT_DIR}
 TAG=${DETECTOR_VERSION}/${DETECTOR_CONFIG}/${TAG}
 
 # Copy input file from xrootd
-xrdcp -f ${XRDURL}/${XRDBASE}/../${INPUT_FILE} ${INPUT_DIR}
+xrdcp -f ${XRDURL}/${XRDRBASE}/${INPUT_FILE} ${INPUT_DIR}
 
 # Output file names
 LOG_DIR=LOG/${TAG}

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -63,7 +63,7 @@ BASEDIR=${DATADIR:-${PWD}}
 
 # XRD Write locations
 XRDURL="xroots://dtn2201.jlab.org/"
-XRDBASE="/eic/eic2/EPIC/xrdtest"
+XRDBASE=${XRDBASE:-"/eic/eic2/EPIC/xrdtest"}
 
 # XRD Read locations
 XRDRURL="root://dtn-eic.jlab.org/"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -62,8 +62,8 @@ fi
 BASEDIR=${DATADIR:-${PWD}}
 
 # XRD Read and Write locations
-XRDURL="root://dtn-eic.jlab.org//work/eic2/EPIC"
-XRDWURL="xroots://dtn2201.jlab.org//eic/eic2/EPIC/xrdtest"
+XRDURL="xroots://dtn2201.jlab.org/"
+XRDBASE="/eic/eic2/EPIC/xrdtest"
 
 # Local temp dir
 echo "SLURM_TMPDIR=${SLURM_TMPDIR:-}"
@@ -107,29 +107,20 @@ mkdir -p ${INPUT_DIR}
 TAG=${DETECTOR_VERSION}/${DETECTOR_CONFIG}/${TAG}
 
 # Copy input file from xrootd
-xrdcp -f ${XRDURL}/${INPUT_FILE} ${INPUT_DIR}
+xrdcp -f ${XRDURL}/${XRDBASE}/../${INPUT_FILE} ${INPUT_DIR}
 
 # Output file names
-LOG_DIR=${XRDWURL}/LOG/${TAG}
-LOG_TEMP=${TMPDIR}/LOG/${TAG}
+LOG_DIR=LOG/${TAG}
+LOG_TEMP=${TMPDIR}/${LOG_DIR}
 mkdir -p ${LOG_TEMP}
-if [ "${COPYLOG:-false}" == "true" ] ; then
-  xrdcp --force --recursive ${TMPDIR}/LOG ${XRDWURL}
-fi
 #
-FULL_DIR=${XRDWURL}/FULL/${TAG}
-FULL_TEMP=${TMPDIR}/FULL/${TAG}
+FULL_DIR=FULL/${TAG}
+FULL_TEMP=${TMPDIR}/${FULL_DIR}
 mkdir -p ${FULL_TEMP}
-if [ "${COPYFULL:-false}" == "true" ] ; then
-  xrdcp --force --recursive ${TMPDIR}/FULL ${XRDWURL}
-fi
 #
-RECO_DIR=${XRDWURL}/RECO/${TAG}
-RECO_TEMP=${TMPDIR}/RECO/${TAG}
+RECO_DIR=RECO/${TAG}
+RECO_TEMP=${TMPDIR}/${RECO_DIR}
 mkdir -p ${RECO_TEMP}
-if [ "${COPYRECO:-false}" == "true" ] ; then
-  xrdcp --force --recursive ${TMPDIR}/RECO ${XRDWURL}
-fi
 
 # Run simulation
 {
@@ -156,8 +147,9 @@ fi
 
 # Data egress to directory
 if [ "${COPYFULL:-false}" == "true" ] ; then
-  xrdcp --force --recursive ${FULL_TEMP}/${TASKNAME}.edm4hep.root ${FULL_DIR}
-  xrdfs ${XRDURL} ls -l ${FULL_DIR}/${TASKNAME}.edm4hep.root
+  xrdfs ${XRDURL} mkdir -p ${XRDBASE}/${FULL_DIR}
+  xrdcp --force --recursive ${FULL_TEMP}/${TASKNAME}.edm4hep.root ${XRDURL}/${XRDBASE}/${FULL_DIR}
+  xrdfs ${XRDURL} ls -l ${XRDBASE}/${FULL_DIR}/${TASKNAME}.edm4hep.root
 fi
 
 # Run eicrecon reconstruction
@@ -182,12 +174,14 @@ ls -al ${LOG_TEMP}/${TASKNAME}.*
 
 # Data egress to directory
 if [ "${COPYRECO:-false}" == "true" ] ; then
-  xrdcp --force --recursive ${RECO_TEMP}/${TASKNAME}*.edm4eic.root ${RECO_DIR}
-  xrdfs ${XRDURL} ls -l ${RECO_DIR}/${TASKNAME}*.edm4eic.root
+  xrdfs ${XRDURL} mkdir -p ${XRDBASE}/${RECO_DIR}
+  xrdcp --force --recursive ${RECO_TEMP}/${TASKNAME}*.edm4eic.root ${XRDURL}/${XRDBASE}/${RECO_DIR}
+  xrdfs ${XRDURL} ls -l ${XRDBASE}/${RECO_DIR}/${TASKNAME}*.edm4eic.root
 fi
 if [ "${COPYLOG:-false}" == "true" ] ; then
-  xrdcp --force --recursive ${LOG_TEMP}/${TASKNAME}.* ${LOG_DIR}
-  xrdfs ${XRDURL} ls -l ${LOG_DIR}/${TASKNAME}.*
+  xrdfs ${XRDURL} mkdir -p ${XRDBASE}/${LOG_DIR}
+  xrdcp --force --recursive ${LOG_TEMP}/${TASKNAME}.* ${XRDURL}/${XRDBASE}/${LOG_DIR}
+  xrdfs ${XRDURL} ls -l ${XRDBASE}/${LOG_DIR}/${TASKNAME}.*
 fi
 
 # closeout

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -62,8 +62,8 @@ fi
 BASEDIR=${DATADIR:-${PWD}}
 
 # XRD Write locations
-XRDURL="xroots://dtn2201.jlab.org/"
-XRDBASE=${XRDBASE:-"/eic/eic2/EPIC/xrdtest"}
+XRDWURL="xroots://dtn2201.jlab.org/"
+XRDWBASE=${XRDWBASE:-"/eic/eic2/EPIC/xrdtest"}
 
 # XRD Read locations
 XRDRURL="root://dtn-eic.jlab.org/"
@@ -151,9 +151,9 @@ mkdir -p ${RECO_TEMP}
 
 # Data egress to directory
 if [ "${COPYFULL:-false}" == "true" ] ; then
-  xrdfs ${XRDURL} mkdir -p ${XRDBASE}/${FULL_DIR}
-  xrdcp --force --recursive ${FULL_TEMP}/${TASKNAME}.edm4hep.root ${XRDURL}/${XRDBASE}/${FULL_DIR}
-  xrdfs ${XRDURL} ls -l ${XRDBASE}/${FULL_DIR}/${TASKNAME}.edm4hep.root
+  xrdfs ${XRDWURL} mkdir -p ${XRDWBASE}/${FULL_DIR}
+  xrdcp --force --recursive ${FULL_TEMP}/${TASKNAME}.edm4hep.root ${XRDWURL}/${XRDWBASE}/${FULL_DIR}
+  xrdfs ${XRDWURL} ls -l ${XRDWBASE}/${FULL_DIR}/${TASKNAME}.edm4hep.root
 fi
 
 # Run eicrecon reconstruction
@@ -178,14 +178,14 @@ ls -al ${LOG_TEMP}/${TASKNAME}.*
 
 # Data egress to directory
 if [ "${COPYRECO:-false}" == "true" ] ; then
-  xrdfs ${XRDURL} mkdir -p ${XRDBASE}/${RECO_DIR}
-  xrdcp --force --recursive ${RECO_TEMP}/${TASKNAME}*.edm4eic.root ${XRDURL}/${XRDBASE}/${RECO_DIR}
-  xrdfs ${XRDURL} ls -l ${XRDBASE}/${RECO_DIR}/${TASKNAME}*.edm4eic.root
+  xrdfs ${XRDWURL} mkdir -p ${XRDWBASE}/${RECO_DIR}
+  xrdcp --force --recursive ${RECO_TEMP}/${TASKNAME}*.edm4eic.root ${XRDWURL}/${XRDWBASE}/${RECO_DIR}
+  xrdfs ${XRDWURL} ls -l ${XRDWBASE}/${RECO_DIR}/${TASKNAME}*.edm4eic.root
 fi
 if [ "${COPYLOG:-false}" == "true" ] ; then
-  xrdfs ${XRDURL} mkdir -p ${XRDBASE}/${LOG_DIR}
-  xrdcp --force --recursive ${LOG_TEMP}/${TASKNAME}.* ${XRDURL}/${XRDBASE}/${LOG_DIR}
-  xrdfs ${XRDURL} ls -l ${XRDBASE}/${LOG_DIR}/${TASKNAME}.*
+  xrdfs ${XRDWURL} mkdir -p ${XRDWBASE}/${LOG_DIR}
+  xrdcp --force --recursive ${LOG_TEMP}/${TASKNAME}.* ${XRDWURL}/${XRDWBASE}/${LOG_DIR}
+  xrdfs ${XRDWURL} ls -l ${XRDWBASE}/${LOG_DIR}/${TASKNAME}.*
 fi
 
 # closeout

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -64,7 +64,7 @@ BASEDIR=${DATADIR:-${PWD}}
 # XRD Read and Write locations
 XRDURL="xroots://dtn2201.jlab.org/"
 XRDBASE="/eic/eic2/EPIC/xrdtest"
-XRDRBASE="/eic/eic2/EPIC"  # Separate variable for read base directory for now. 
+XRDRBASE="/eic/eic2/EPIC"  # Separate variable for read base directory for now.
 
 # Local temp dir
 echo "SLURM_TMPDIR=${SLURM_TMPDIR:-}"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Copy the empty directory structure to xrootd before any files are created. For now, using the xrdtest directory as the test location. This needs to be omitted in full production scenario.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
