### PR TITLE
#Draft/WIP: Simplify lookup of scratch directory

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -173,5 +173,3 @@ fi
 
 # closeout
 date
-find ${TMPDIR}
-du -sh ${TMPDIR}

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -70,8 +70,8 @@ XRDRURL="root://dtn-eic.jlab.org/"
 XRDRBASE="/work/eic2/EPIC"
 
 # Local temp dir
+TMPDIR=${WORK_DIR:-/tmp}
 echo "TMPDIR=${TMPDIR}"
-mkdir -p ${TMPDIR}
 ls -al ${TMPDIR}
 
 # Input file parsing

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -70,23 +70,6 @@ XRDRURL="root://dtn-eic.jlab.org/"
 XRDRBASE="/work/eic2/EPIC"
 
 # Local temp dir
-echo "SLURM_TMPDIR=${SLURM_TMPDIR:-}"
-echo "SLURM_JOB_ID=${SLURM_JOB_ID:-}"
-echo "SLURM_ARRAY_JOB_ID=${SLURM_ARRAY_JOB_ID:-}"
-echo "SLURM_ARRAY_TASK_ID=${SLURM_ARRAY_TASK_ID:-}"
-echo "_CONDOR_SCRATCH_DIR=${_CONDOR_SCRATCH_DIR:-}"
-echo "OSG_WN_TMP=${OSG_WN_TMP:-}"
-if [ -n "${_CONDOR_SCRATCH_DIR:-}" ] ; then
-  TMPDIR=${_CONDOR_SCRATCH_DIR}
-elif [ -n "${SLURM_TMPDIR:-}" ] ; then
-  TMPDIR=${SLURM_TMPDIR}
-else
-  if [ -d "/scratch/slurm/${SLURM_JOB_ID:-}" ] ; then
-    TMPDIR="/scratch/slurm/${SLURM_JOB_ID:-}"
-  else
-    TMPDIR=${TMPDIR:-/tmp}/${$}
-  fi
-fi
 echo "TMPDIR=${TMPDIR}"
 mkdir -p ${TMPDIR}
 ls -al ${TMPDIR}


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Different systems use different scratch spaces. We can pass this through the template file specific to the site the jobs are being submitted from. For example, on OSG https://github.com/eic/job_submission_condor/blob/main/templates/osg_csv.sh.in. 

export TMPDIR=${_CONDOR_SCRATCH_DIR}

On JLAB slurm,
export TMPDIR=/scratch/slurm

On CEDAR/narval slurm,

export TMPDIR=$SLURM_TMPDIR

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
