### PR TITLE
run.sh: make full geant track history available to EICrecon

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -144,7 +144,6 @@ mkdir -p ${RECO_TEMP} ${BASEDIR}/${RECO_DIR}
     --enableGun \
     --steeringFile ${INPUT_FILE} \
     --numberOfEvents ${EVENTS_PER_TASK} \
-    --part.minimalKineticEnergy 1*TeV \
     --filter.tracker 'edep0' \
     --compactFile ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml \
     --outputFile ${FULL_TEMP}/${TASKNAME}.edm4hep.root


### PR DESCRIPTION
Few reasons for doing this:

1. This is consistent with what users have set by default (and what is debugged for)
2. Should not cause a significant intermediate file bloat
3. We need this if we want to start enabling associations not with just status=1 particles