### PR TITLE
fix: jug_xl -> eic_xl; cvmfs-contrib/github-action-cvmfs@v4; actions/checkout@v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,11 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: actions/checkout@v4
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
-        platform-release: "jug_xl:nightly"
+        platform-release: "eic_xl:nightly"
         setup: /opt/detector/epic-main/bin/thisepic.sh
         run: |
           test "$(scripts/generate.sh)" = "e-_1GeV_45to135deg.steer"
@@ -35,11 +35,11 @@ jobs:
     needs: generate
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: actions/checkout@v4
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
-        platform-release: "jug_xl:nightly"
+        platform-release: "eic_xl:nightly"
         setup: /opt/detector/epic-main/bin/thisepic.sh
         run: |
           scripts/run.sh EVGEN/SINGLE/e-/1GeV/45to135deg/e-_1GeV_45to135deg.steer 100
@@ -48,11 +48,11 @@ jobs:
     needs: generate
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: actions/checkout@v4
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
-        platform-release: "jug_xl:nightly"
+        platform-release: "eic_xl:nightly"
         setup: /opt/detector/epic-main/bin/thisepic.sh
         run: |
           scripts/run.sh EVGEN/SINGLE/pi+/1GeV/3to50deg/pi+_1GeV_3to50deg.steer 100 0001

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: eicweb.phy.anl.gov:4567/eic/juggler/juggler:latest
+image: eicweb.phy.anl.gov:4567/containers/eic_container/eic_xl:nightly
 
 stages:
   - config
@@ -20,7 +20,7 @@ generate:
     matrix:
       - TAG:
         - "nightly"
-  image: eicweb.phy.anl.gov:4567/containers/eic_container/jug_xl:${TAG}
+  image: eicweb.phy.anl.gov:4567/containers/eic_container/eic_xl:${TAG}
 
 run_electron_1GeV_45to135deg:
   extends: .test


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR replaces instances of jug_xl to eic_xl.